### PR TITLE
FEAT: auth.py et main.py pour api-gateway

### DIFF
--- a/srcs/backend/api-gateway/app/auth.py
+++ b/srcs/backend/api-gateway/app/auth.py
@@ -1,0 +1,45 @@
+# verifier la validite du token en le comparant avec la clet secrete KV (signature, expiration, algo, ...)
+# renvoi erreur si header manquant ou token invalid
+
+import jwt
+from fastapi import Header, HTTPException, status
+from jwt import InvalidTokenError
+
+
+from .vault_kv import read_jwt_secret
+
+JWT_SECRET_KEY, JWT_ALGORITHM = read_jwt_secret()
+
+# Verifie la validite du token envoye (KEY check signature, ALGO check algo accepte)
+# fonction .decode raise exception si invalid
+def check_jwt(token: str) -> dict:
+    payload = jwt.decode(token, JWT_SECRET_KEY, JWT_ALGORITHM)
+    return payload
+
+# on accepte nonepour analyser et envoyer notre propre message d erreur et ne pas laisser Fastapi faire seul
+# split (" ", 1) -> " " -> separator le format de authorization
+# est en 2 parts (bearer 42254) le 1 est explicite pour 
+# ne cut qu une fois au cas ou le token serait avec des espaces
+# il y a beaucoup de header mais ici seul le header "authorization" nous interesse car c est ici 
+# que se trouve le token pour l'authentification (Authorization: Bearer <token>)
+# Seul un user authentifie peut continuer la route
+# return payload si valid ou erreur 4xx si invalid
+def require_user(authorization: str | None = Header(default=None)) -> dict:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authorization header must be : bearer <token>",
+        )
+    try:
+        return check_jwt(parts[1])
+    except InvalidTokenError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )

--- a/srcs/backend/api-gateway/app/main.py
+++ b/srcs/backend/api-gateway/app/main.py
@@ -18,3 +18,63 @@ PROFILE_SERVICE_URL = os.getenv("PROFILE_SERVICE_URL")
 def health():
     return {"status": "ok", "service": "api-gateway"}
 
+# headers = {}  # Dictionnaire vide
+
+# for k, v in request.headers.items():
+    # k = clé (ex: "host", "authorization")
+    # v = valeur (ex: "api-gateway:8000", "Bearer xxx")
+    
+    # if k.lower() != "host":  # Si ce n'est PAS "host"
+        # headers[k] = v       # On l'ajoute au dictionnaire
+
+# Résultat:
+# headers = {
+#   "authorization": "Bearer xxx",
+#   "content-type": "application/json"
+# }
+# lorsqu'une fonction est async le retour se fait avec 
+# await (coroutine retourne adresse sans await car reponse incomplete il faut donc attendre avec await)
+
+async def _proxy(request: Request, target_base: str, path: str) -> Response:
+    target_url = f"{target_base}/{path}"
+    body = await request.body()
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    async with httpx.AsyncClient() as client:
+        response = await client.request(
+            method=request.method,
+            url=target_url,
+            params=dict(request.query_params),
+            content=body,
+            headers=headers,
+        )
+        return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+
+
+
+# path:path -> parametre de la fonction et type (permet la gestion des "/") 
+# Fastapi fais la liaison auto entre le parametre de la route et la signature de la fonction 
+
+# pas de dict depends car on doit povoir y acceder sans etre log
+@app.api_route("/users/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_users(path: str, request: Request):
+    return await _proxy(request, USER_SERVICE_URL, path)
+
+@app.api_route("/game/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_game(path: str, request: Request, user: dict = Depends(require_user)):
+    return await _proxy(request, GAME_SERVICE_URL, path)
+
+@app.api_route("/chat/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_chat(path: str, request: Request, user: dict = Depends(require_user)):
+    return await _proxy(request, CHAT_SERVICE_URL, path)
+
+@app.api_route("/friends/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_friends(path: str, request: Request, user: dict = Depends(require_user)):
+    return await _proxy(request, FRIENDS_SERVICE_URL, path)
+
+@app.api_route("/analytics/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_analytics(path: str, request: Request, user: dict = Depends(require_user)):
+    return await _proxy(request, ANALYTICS_SERVICE_URL, path)
+
+@app.api_route("/profile/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+async def proxy_profile(path: str, request: Request, user: dict = Depends(require_user)):
+    return await _proxy(request, PROFILE_SERVICE_URL, path)

--- a/srcs/backend/api-gateway/app/main.py
+++ b/srcs/backend/api-gateway/app/main.py
@@ -1,0 +1,20 @@
+import os
+import httpx
+from fastapi import FastAPI, Request, Depends
+from fastapi.responses import Response
+
+from .auth import require_user
+
+app = FastAPI(title="api-gateway")
+
+USER_SERVICE_URL = os.getenv("USER_SERVICE_URL")
+CHAT_SERVICE_URL = os.getenv("CHAT_SERVICE_URL")
+ANALYTICS_SERVICE_URL = os.getenv("ANALYTICS_SERVICE_URL")
+FRIENDS_SERVICE_URL = os.getenv("FRIENDS_SERVICE_URL")
+GAME_SERVICE_URL = os.getenv("GAME_SERVICE_URL")
+PROFILE_SERVICE_URL = os.getenv("PROFILE_SERVICE_URL")
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "service": "api-gateway"}
+


### PR DESCRIPTION
implementation des fichiers auth et main .py du gateway-api qui sert a filtrer les users logs avec un token valide, sans bloque la page register ou login, puis redirrige les requetes sur le micro service demande

Ajout couche authentificationdans  API Gateway.

- Implementation auth.py et main.py 
- Validation JWT tokens pour securiser le routage
- Autorise  un acces publique a la page de login/register
- Redirige les requetes vers le micro-service aproprie

Client
   │
   ▼
API Gateway
   │
   ├── check JWT
   │
   ├── allow login/register
   │
   └── forward request
        │
        ▼
   microservice