### PR TITLE
Fix: rendre le stack healthy sous podman-compose (healthchecks + Vault perms + Vault DB roles)

### DIFF
--- a/srcs/.env.example
+++ b/srcs/.env.example
@@ -33,6 +33,6 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # Frontend
 # URL de l'API backend
-REACT_APP_API_URL=http://localhost/api
+REACT_APP_API_URL=http://api
 # URL du WebSocket (pour les communications temps réel)
-REACT_APP_WS_URL=ws://localhost/ws
+REACT_APP_WS_URL=ws://ws

--- a/srcs/backend/analytics-service/Dockerfile
+++ b/srcs/backend/analytics-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="analytics-service"
 

--- a/srcs/backend/analytics-service/app/main.py
+++ b/srcs/backend/analytics-service/app/main.py
@@ -28,3 +28,8 @@ def ensure_user_schema() -> None:
 	except Exception:
 		# Don't block startup if DB isn't reachable yet.
 		return
+
+
+@app.get("/health")
+async def health():
+	return {"status": "ok"}

--- a/srcs/backend/api-gateway/Dockerfile
+++ b/srcs/backend/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="api-gateway"
 

--- a/srcs/backend/chat-service/Dockerfile
+++ b/srcs/backend/chat-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="chat-service"
 

--- a/srcs/backend/chat-service/app/main.py
+++ b/srcs/backend/chat-service/app/main.py
@@ -29,3 +29,8 @@ def ensure_user_schema() -> None:
 	except Exception:
 		# Don't block startup if DB isn't reachable yet.
 		return
+
+
+@app.get("/health")
+async def health():
+	return {"status": "ok"}

--- a/srcs/backend/friends-service/Dockerfile
+++ b/srcs/backend/friends-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="friends-service"
 

--- a/srcs/backend/friends-service/app/main.py
+++ b/srcs/backend/friends-service/app/main.py
@@ -28,3 +28,8 @@ def ensure_user_schema() -> None:
 	except Exception:
 		# Don't block startup if DB isn't reachable yet.
 		return
+
+
+@app.get("/health")
+async def health():
+	return {"status": "ok"}

--- a/srcs/backend/game-service/Dockerfile
+++ b/srcs/backend/game-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="game-service"
 

--- a/srcs/backend/game-service/app/main.py
+++ b/srcs/backend/game-service/app/main.py
@@ -28,3 +28,8 @@ def ensure_user_schema() -> None:
 	except Exception:
 		# Don't block startup if DB isn't reachable yet.
 		return
+
+
+@app.get("/health")
+async def health():
+	return {"status": "ok"}

--- a/srcs/backend/profile-service/Dockerfile
+++ b/srcs/backend/profile-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="profile-service"
 

--- a/srcs/backend/profile-service/app/main.py
+++ b/srcs/backend/profile-service/app/main.py
@@ -28,3 +28,8 @@ def ensure_user_schema() -> None:
 	except Exception:
 		# Don't block startup if DB isn't reachable yet.
 		return
+
+
+@app.get("/health")
+async def health():
+	return {"status": "ok"}

--- a/srcs/backend/user-service/Dockerfile
+++ b/srcs/backend/user-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM docker.io/python:3.11-slim
 
 LABEL service="user-service"
 

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -190,6 +190,7 @@ services:
       context: ./vault
       dockerfile: Dockerfile
     image: vault
+    user: "0:0"
     env_file:
       - .env
     expose:
@@ -202,6 +203,7 @@ services:
       - IPC_LOCK
     networks:
       - transcendence-backend
+      - transcendence-database
     restart: unless-stopped
     depends_on:
       user-db:
@@ -480,11 +482,11 @@ services:
 
 ## WAF ####
 
-  # WAF:
+  # waf:
   #   build:
   #     context: ./waf
   #     dockerfile: Dockerfile
-  #   image: WAF
+  #   image: waf
   #   ports:
   #     - "80:80"
   #     - "443:443"

--- a/srcs/frontend/Dockerfile
+++ b/srcs/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM docker.io/node:20-alpine
 
 WORKDIR /app
 

--- a/srcs/postgres-databases/Dockerfile
+++ b/srcs/postgres-databases/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/postgres:15.5-alpine
+FROM docker.io/postgres:15.5-alpine
 
 EXPOSE 5432

--- a/srcs/vault/Dockerfile
+++ b/srcs/vault/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/vault:1.15
+FROM docker.io/hashicorp/vault:1.15
 
 COPY config/ /vault/config
 

--- a/srcs/vault/scripts/setting.sh
+++ b/srcs/vault/scripts/setting.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 INIT_FILE_JSON="/vault/data/init.json"
 
+# changer les droits sur le dir vault/data car monte de base en 700
+chmod 711 /vault/data || true
+
 export VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"
 
 echo "Initialisation Vault..."
@@ -106,21 +109,37 @@ config_db(){
   local host="$2"
   local db_name="$3"
   local role_name="$4"
+  local group_role="${config_name//-/_}_app"
   local sslmode="${VAULT_DB_SSLMODE:-disable}"
+  local max_attempts="${VAULT_DB_MAX_ATTEMPTS:-30}"
+  local sleep_seconds="${VAULT_DB_RETRY_SLEEP_SECONDS:-2}"
 
   echo "Config DB '$config_name' (host=$host, db=$db_name, role=$role_name)..."
-  vault write "database/config/$config_name" \
-    plugin_name=postgresql-database-plugin \
-    allowed_roles="$role_name" \
-    connection_url="postgresql://{{username}}:{{password}}@$host:5432/$db_name?sslmode=$sslmode" \
-    username="${POSTGRES_USER:?POSTGRES_USER must be set and not empty}" \
-    password="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set and not empty}"
+  local attempt=1
+  while true; do
+    if vault write "database/config/$config_name" \
+      plugin_name=postgresql-database-plugin \
+      allowed_roles="$role_name" \
+      connection_url="postgresql://{{username}}:{{password}}@$host:5432/$db_name?sslmode=$sslmode" \
+      username="${POSTGRES_USER:?POSTGRES_USER must be set and not empty}" \
+      password="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set and not empty}" \
+      && vault write "database/roles/$role_name" \
+        db_name="$config_name" \
+        creation_statements="DO \$\$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${group_role}') THEN CREATE ROLE ${group_role} NOLOGIN; END IF; END \$\$; CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT ${group_role} TO \"{{name}}\"; GRANT CONNECT ON DATABASE \"${db_name}\" TO ${group_role}; GRANT USAGE, CREATE ON SCHEMA public TO ${group_role}; GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${group_role}; GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO ${group_role}; ALTER DEFAULT PRIVILEGES FOR ROLE \"{{name}}\" IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ${group_role}; ALTER DEFAULT PRIVILEGES FOR ROLE \"{{name}}\" IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO ${group_role};" \
+        default_ttl="1h" \
+        max_ttl="24h"; then
+      break
+    fi
 
-  vault write database/roles/$role_name \
-    db_name="$config_name" \
-    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';" \
-    default_ttl="1h" \
-    max_ttl="24h"
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "ERROR: failed to configure DB '$config_name' after ${max_attempts} attempts" >&2
+      return 1
+    fi
+
+    echo "Retrying DB '$config_name' (${attempt}/${max_attempts}) in ${sleep_seconds}s..."
+    attempt=$((attempt + 1))
+    sleep "$sleep_seconds"
+  done
 }
 
 config_db "user-db" "user-db" "user_db" "user-role"
@@ -153,8 +172,14 @@ create_token() {
   local policy="$1"
   local file="$2"
 
+  local token_uid="${VAULT_TOKEN_UID:-1000}"
+  local token_gid="${VAULT_TOKEN_GID:-1000}"
+
   if [ -f "$file" ]; then
-    echo "Token already created for '$policy', skipping."
+    # Ensure permissions are usable by non-root app containers.
+    chmod 600 "$file" || true
+    chown "$token_uid:$token_gid" "$file" || true
+    echo "Token already created for '$policy', skipping creation."
     return
   fi
 
@@ -167,6 +192,7 @@ create_token() {
   fi
   echo "$token" > "$file"
   chmod 600 "$file"
+  chown "$token_uid:$token_gid" "$file" || true
 }
 
 # Creation token Vault pour autoriser l'acces a la lecture des fichiers specifies dans policies

--- a/srcs/waf/Dockerfile
+++ b/srcs/waf/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/modsecurity-crs:nginx-alpine
+FROM docker.io/owasp/modsecurity-crs:nginx-alpine
 
 COPY ./conf/nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
Résumé
Cette PR stabilise l’exécution du stack sous Podman (podman-compose) en corrigeant:
- healthchecks /health,
- permissions/ownership des tokens Vault partagés en volume,
- configuration Vault database secrets engine (retries + privilèges DB adaptés aux users dynamiques),
- compat “short-name images” via base images fully-qualified.

Changements principaux
- Micro-services: ajout /health pour satisfaire les healthchecks.
- Vault:
  - /vault/data rendu traversable (chmod 711) pour permettre la lecture ciblée des tokens.
  - tokens: chmod 600 + chown vers UID/GID applicatif (1000) pour éviter PermissionError.
  - Vault s’exécute en root pour pouvoir modifier les perms du volume.
  - retry loop sur la config database secrets engine.
  - rôles DB dynamiques:
    - création d’un rôle de groupe stable par DB,
    - GRANT CONNECT + schema/public + tables/sequences + default privileges,
    - fix du DO $$ ... $$ (échappement) pour éviter l’expansion bash ($$ -> PID).

Pourquoi
- Sous Podman, les volumes et permissions diffèrent souvent de Docker rootful.
- Les users DB dynamiques (TTL) doivent conserver l’accès aux objets DB même après rotation.

Tests
- `docker compose down && docker compose up -d --build`
- Vérifié: tous les containers passent healthy
- Vérifié: Vault peut générer des creds DB (lecture database/creds/* OK)
- Vérifié: /health renvoie 200 sur les services