### PR TITLE
WAF/HTTPS + Auth same-origin (/api) + réseau edge + Vault perms + Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ PATH_VOLUMES = ./srcs/data
 all:  up
 
 up:
+	$(DOCK_COMP) up -d --build
+
+upfg:
 	$(DOCK_COMP) up --build
 
 down:
-	$(DOCK_COMP) down
+	$(DOCK_COMP) down --remove-orphans
 
 logs:
 	$(DOCK_COMP) logs -f
@@ -16,14 +19,14 @@ ports:
 	$(DOCK_COMP) ps
 
 clean:
-	$(DOCK_COMP) down --volumes
+	$(DOCK_COMP) down --volumes --remove-orphans
 
 fclean: clean
 	@docker system prune -af
 	rm -rf  $(PATH_VOLUMES)
 
 restart:
-	@$(DOCK_COMP) down
-	@$(DOCK_COMP) up --build --force-recreate
+	@$(DOCK_COMP) down --remove-orphans
+	@$(DOCK_COMP) up -d --build --force-recreate
 
-.PHONY: all up down logs ports clean fclean restart
+.PHONY: all up upfg down logs ports clean fclean restart

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -6,6 +6,9 @@ networks:
   transcendence-frontend:
     name: transcendence-frontend
     driver: bridge
+  transcendence-edge:
+    name: transcendence-edge
+    driver: bridge
   transcendence-backend:
     name: transcendence-backend
     driver: bridge
@@ -245,7 +248,7 @@ services:
       - vault-data:/vault/data:ro 
     networks:
       - transcendence-backend
-      - transcendence-frontend
+      - transcendence-edge
     depends_on:
       vault:
         condition: service_healthy
@@ -495,6 +498,7 @@ services:
       - "8443:443"
     networks:
       - transcendence-frontend
+      - transcendence-edge
     depends_on:
       api-gateway:
         condition: service_healthy

--- a/srcs/frontend/src/log/useAuth.ts
+++ b/srcs/frontend/src/log/useAuth.ts
@@ -3,28 +3,76 @@ import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 
+/**
+ * FICHIER: useAuth.ts
+ *
+ * Rôle:
+ * - Centralise la logique d'authentification côté frontend sous forme de hooks React:
+ *   - useLogin(): connexion
+ *   - useRegister(): inscription
+ *
+ * Où c'est utilisé ?
+ * - useLogin() est utilisé par le composant Handlelog.tsx (page /login)
+ * - useRegister() est utilisé par le composant Handleregister.tsx (page /register)
+ *   Les routes sont déclarées dans App.tsx.
+ *
+ * Architecture réseau (IMPORTANT pour comprendre les URLs):
+ * - Le navigateur ouvre l'UI via le WAF: http://localhost:8080
+ * - Le WAF (nginx) reverse-proxy:
+ *     - /           -> frontend:3000 (dev server Vite)
+ *     - /api/*      -> api-gateway:8000
+ * - L'API Gateway expose notamment:
+ *     - POST /auth/login  (login)
+ *     - GET  /auth/me     (récupère le payload du JWT)
+ *     - et proxy /users/* vers le user-service
+ *
+ * Donc, depuis le frontend on appelle une URL relative:
+ * - /api/auth/login, /api/auth/me, /api/users/auth/register
+ * pour rester en "same-origin" (même origine) et éviter les problèmes CORS.
+ */
+
 export const useLogin = () => {
+  // Champs du formulaire ("identifier" = username OU email) + mot de passe
   const [identifier, setIdentifier] = useState("");
   const [password, setPassword] = useState("");
+
+  // message = feedback UI (succès/erreur), loading = spinner pendant le fetch
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
+
+  // navigate = redirection (React Router), t() = traduction i18n
   const navigate = useNavigate();
   const { t } = useTranslation();
+
+  // Base d'API "same-origin": tout passe par le WAF.
+  // - Le navigateur parle uniquement à http://localhost:8080 ou https://localhost:8443 
+  // - Le WAF forward /api/* vers api-gateway
+  // => évite CORS (sinon 8080 -> 8000 serait cross-origin).
+  const API_BASE_URL = "/api";
   
+  // Handler du submit du formulaire de login.
   const login = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // Reset état UI
     setLoading(true);
     setMessage("");
     
+    // Une fois le token récupéré, on appelle /auth/me pour récupérer le payload (username, email, sub)
+    // et on stocke dans localStorage pour l'utiliser ailleurs (ex: page /profile).
     const getUserInfo = async (token: string) => {
         try {
-            const response = await fetch("http://localhost:8000/auth/me", {
+            // Appel same-origin; /api/* est proxifié par le WAF vers l'api-gateway.
+        const response = await fetch(`${API_BASE_URL}/auth/me`, {
                 headers: {
                     "Authorization": `Bearer ${token}`,
                 },
             });
             const data = await response.json();
             if (response.ok) {
+                // On stocke le token et quelques infos utiles localement.
+                // NOTE: c'est un choix d'implémentation; côté sécurité, il faut garder en tête
+                // que localStorage est accessible via JS (XSS => risque).
                 localStorage.setItem("access_token", token);
           const payload = data?.payload;
           if (payload?.username) {
@@ -45,7 +93,9 @@ export const useLogin = () => {
     };
   
     try {
-      const response = await fetch("http://localhost:8000/auth/login", {
+      // Appel same-origin; correspond à POST /auth/login côté api-gateway.
+      // Le body { identifier, password } est validé côté api-gateway puis user-service.
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -56,15 +106,19 @@ export const useLogin = () => {
       const data = await response.json();
 
       if (response.ok) {
+        // Succès: on récupère data.access_token, puis on charge /auth/me.
         setMessage(t("Connexion Successful"));
         getUserInfo(data.access_token);
         setTimeout(() => {
+          // Redirection vers /profile (route définie dans App.tsx).
           navigate("/profile");
         }, 2000);
       } else {
+        // Erreur: message API si présent, sinon fallback.
         setMessage(data.error?.message || t("Login failed"));
       }
     } catch (error) {
+      // Erreur réseau / exception fetch
       setMessage(t("An error occurred. Please try again."));
     }
     setLoading(false);
@@ -82,23 +136,33 @@ export const useLogin = () => {
 };
 
 export const useRegister = () => {
+  // Champs du formulaire d'inscription
   const [username, setUsername] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
+
+  // navigate = redirection vers /login après succès
   const navigate = useNavigate();
   const { t } = useTranslation();
   
 
   const register = async (e: React.FormEvent) => {
     e.preventDefault();
+
+  // Vérification simple côté client avant l'appel API.
     if (password !== confirmPassword) {
       setMessage(t("Passwords do not match"));
       return;
     }
     try{
-        const response = await fetch("http://localhost:8000/users/auth/register", {
+    // Appel same-origin: on passe par l'api-gateway via /api.
+    // Chemin complet:
+    //   Browser -> WAF (/api/users/auth/register)
+    //   WAF -> api-gateway (/users/auth/register)
+    //   api-gateway -> user-service (proxy /users/*)
+      const response = await fetch(`${API_BASE_URL}/users/auth/register`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -106,15 +170,18 @@ export const useRegister = () => {
             body: JSON.stringify({username, email, password}),})
 
             if (response.ok) {
+        // Succès: message puis redirection vers /login.
                 setMessage(t("Registration successful"));
                 setTimeout(() => {
                     navigate("/login");
                 }, 2000);
             }
             else {                const data = await response.json();
+        // Erreur: message API si présent, sinon fallback.
                 setMessage(data.error?.message || t("Registration failed"));
             }
     } catch (error) {
+    // Erreur réseau / exception fetch
         setMessage(t("An error occurred. Please try again."));
 
     }

--- a/srcs/vault/Dockerfile
+++ b/srcs/vault/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash jq && \
     mkdir -p /vault/data /vault/logs && \
     chmod 775 /vault/scripts && \
     chmod 755 /vault/scripts/*.sh && \
-    chmod 700 /vault/data && \
+    chmod 711 /vault/data && \
     chmod 755 /vault/logs
 
 

--- a/srcs/vault/scripts/setting.sh
+++ b/srcs/vault/scripts/setting.sh
@@ -8,7 +8,10 @@ set -euo pipefail
 
 INIT_FILE_JSON="/vault/data/init.json"
 
-# changer les droits sur le dir vault/data car monte de base en 700
+# changer les droits sur le dir /vault/data : quand il est monté via un volume,
+# les permissions du Dockerfile ne suffisent pas toujours (volume déjà existant).
+# 711 = traverse ok (x) sans lister (r) pour les autres conteneurs non-root.
+mkdir -p /vault/data
 chmod 711 /vault/data || true
 
 export VAULT_ADDR="${VAULT_ADDR:-http://127.0.0.1:8200}"

--- a/srcs/waf/conf/nginx.conf
+++ b/srcs/waf/conf/nginx.conf
@@ -1,5 +1,29 @@
 load_module modules/ngx_http_modsecurity_module.so;
 
+# -----------------------------------------------------------------------------
+# FICHIER: nginx.conf (WAF)
+#
+# Rôle:
+# - Ce conteneur "waf" (nginx + ModSecurity/OWASP CRS) est l'entrée unique exposée
+#   vers l'hôte.
+#
+# Liens avec docker-compose:
+# - service "waf" publie:
+#     - 8080:80  (HTTP)
+#     - 8443:443 (HTTPS)
+# - service "frontend" expose 3000 (Vite dev server, non publié directement)
+# - service "api-gateway" publie 8000:8000 (debug/accès direct possible)
+#
+# Routage appliqué ici:
+# - /api/*  -> api-gateway:8000  (les routes FastAPI)
+# - /ws/*   -> api-gateway:8000/ws/* (WebSockets)
+# - /       -> frontend:3000 (React/Vite)
+#
+# Objectif principal:
+# - Avoir une seule origine côté navigateur (http://localhost:8080),
+#   et faire transiter l'API via /api/* pour éviter CORS.
+# -----------------------------------------------------------------------------
+
 events {
     worker_connections 1024;
 }
@@ -7,6 +31,13 @@ events {
 http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
+    # DNS / Résolution:
+    # - Les upstreams sont des noms de services (api-gateway, frontend) sur le réseau
+    #   de conteneurs.
+    # - ATTENTION: si on utilise `proxy_pass` avec une variable (ex: proxy_pass $api_gateway),
+    #   Nginx bascule sur une résolution dynamique et s'appuie sur la directive `resolver`.
+    #   Sous Podman, une valeur "hardcodée" de resolver peut ne pas fonctionner.
+    # - Solution appliquée plus bas: utiliser des `proxy_pass http://api-gateway:8000/...` statiques.
     resolver 169.254.1.1 10.255.0.53 ipv6=off valid=30s;
 
     map $http_upgrade $connection_upgrade {
@@ -26,6 +57,8 @@ http {
     error_log /var/log/nginx/error.log warn;
 
     # Rate Limiting - Protection contre DDoS/brute force
+    # - zone=api_limit: limite générale pour /api/
+    # - zone=login_limit: plus strict pour les routes sensibles (login/register)
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=login_limit:10m rate=5r/m;
     limit_conn_zone $binary_remote_addr zone=conn_limit:10m;
@@ -50,6 +83,7 @@ http {
     # Cacher la version de Nginx
     server_tokens off;
 
+   
     server {
         listen 80;
         server_name _;
@@ -60,8 +94,12 @@ http {
         location /api/ {
             limit_req zone=api_limit burst=10 nodelay;
 
-            set $api_gateway http://api-gateway:8000;
-            proxy_pass $api_gateway/;
+            # Upstream statique (pas de variable) pour garder une résolution DNS stable sous Podman.
+            # Le slash final est IMPORTANT: il supprime le préfixe `/api/`.
+            # Exemple:
+            #   requête client:  /api/auth/login
+            #   upstream reçoit: /auth/login
+            proxy_pass http://api-gateway:8000/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -78,8 +116,13 @@ http {
         location ~ ^/api/(auth|login|register) {
             limit_req zone=login_limit burst=3 nodelay;
 
-            set $api_gateway http://api-gateway:8000;
-            proxy_pass $api_gateway;
+            # Cette location existe uniquement pour appliquer un rate-limit plus strict.
+            # Sans le rewrite, Nginx forwarderait /api/auth/login en /api/auth/login,
+            # mais l'api-gateway expose /auth/login.
+            rewrite ^/api/(.*)$ /$1 break;
+
+            # Upstream statique (pas de variable) pour éviter les problèmes de resolver.
+            proxy_pass http://api-gateway:8000;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -89,8 +132,9 @@ http {
 
         # WebSocket pour le jeu/chat
         location /ws/ {
-            set $api_gateway http://api-gateway:8000;
-            proxy_pass $api_gateway/ws/;
+            # WebSockets (Upgrade/Connection) vers l'api-gateway.
+            # Ici on forward /ws/* vers /ws/* (pas de strip de préfixe).
+            proxy_pass http://api-gateway:8000/ws/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
@@ -102,6 +146,8 @@ http {
         # Frontend - tout le reste
         location / {
                 modsecurity on;
+            # UI servie par le dev server Vite (React) derrière le WAF.
+            # Dans docker-compose: service "frontend" écoute 3000.
             proxy_pass http://frontend:3000/;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -112,6 +158,160 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
 
             # Répétition des headers globaux (add_header enfant écrase le parent en Nginx)
+            add_header X-Frame-Options "SAMEORIGIN" always;
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header X-XSS-Protection "1; mode=block" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+            add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; font-src 'self';" always;
+        }
+
+        # Autoriser les dépendances Vite en mode dev
+        location ^~ /node_modules/.vite/ {
+            # Exclusion ciblée: on coupe ModSecurity sur les assets dev générés par Vite
+            # (sinon risque de faux positifs / blocages).
+            modsecurity off;
+            proxy_pass http://frontend:3000/node_modules/.vite/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+            # Endpoints techniques Vite/HMR en dev (exclusions ciblées)
+            location ^~ /@vite/ {
+                # Endpoints Vite (dev) nécessaires au fonctionnement du HMR.
+                modsecurity off;
+                proxy_pass http://frontend:3000/@vite/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location = /@react-refresh {
+                # React Fast Refresh (dev).
+                modsecurity off;
+                proxy_pass http://frontend:3000/@react-refresh;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+            location ^~ /src/ {
+                # Accès aux sources en dev (Vite sert /src/*).
+                modsecurity off;
+                proxy_pass http://frontend:3000/src/;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+            }
+
+        # Bloquer l'accès aux fichiers sensibles
+        location ~ /\. {
+            # Bloque les fichiers cachés type .env, .git, etc.
+            return 404;
+        }
+
+        # Page d'erreur personnalisée pour les blocages WAF
+        error_page 403 /403.html;
+        location = /403.html {
+            internal;
+            return 403 '{"error": "Request blocked by security policy"}';
+            add_header Content-Type application/json;
+        }
+    }
+}
+
+    # -------------------------------------------------------------------------
+    # Serveur HTTPS (8443 côté host -> 443 dans le conteneur)
+    #
+    # Pourquoi ça ne marchait pas avant ?
+    # - docker-compose publie bien 8443:443, mais notre config n'avait qu'un
+    #   `server { listen 80; }`.
+    # - Résultat: le port 443 était bien exposé, mais Nginx ne parlait pas TLS dessus,
+    #   donc le navigateur/curl voyait une "connection reset" pendant le handshake.
+    #
+    # Certificat:
+    # - L'image owasp/modsecurity-crs génère un certificat auto-signé au démarrage.
+    # - Chemins observés dans les logs: /etc/nginx/conf/server.crt et /etc/nginx/conf/server.key
+    # -------------------------------------------------------------------------
+    server {
+        listen 443 ssl;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/conf/server.crt;
+        ssl_certificate_key /etc/nginx/conf/server.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        limit_conn conn_limit 50;
+
+        # API Gateway - toutes les requêtes /api/
+        location /api/ {
+            limit_req zone=api_limit burst=10 nodelay;
+
+            proxy_pass http://api-gateway:8000/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_connect_timeout 30s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+        }
+
+        # Endpoints sensibles - rate limiting strict
+        location ~ ^/api/(auth|login|register) {
+            limit_req zone=login_limit burst=3 nodelay;
+
+            rewrite ^/api/(.*)$ /$1 break;
+            proxy_pass http://api-gateway:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # WebSocket pour le jeu/chat
+        location /ws/ {
+            proxy_pass http://api-gateway:8000/ws/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 86400;
+        }
+
+        # Frontend - tout le reste
+        location / {
+            modsecurity on;
+            proxy_pass http://frontend:3000/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
             add_header X-Frame-Options "SAMEORIGIN" always;
             add_header X-Content-Type-Options "nosniff" always;
             add_header X-XSS-Protection "1; mode=block" always;
@@ -133,42 +333,42 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-            # Endpoints techniques Vite/HMR en dev (exclusions ciblées)
-            location ^~ /@vite/ {
-                modsecurity off;
-                proxy_pass http://frontend:3000/@vite/;
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection $connection_upgrade;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-            }
+        # Endpoints techniques Vite/HMR en dev (exclusions ciblées)
+        location ^~ /@vite/ {
+            modsecurity off;
+            proxy_pass http://frontend:3000/@vite/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
-            location = /@react-refresh {
-                modsecurity off;
-                proxy_pass http://frontend:3000/@react-refresh;
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection $connection_upgrade;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-            }
+        location = /@react-refresh {
+            modsecurity off;
+            proxy_pass http://frontend:3000/@react-refresh;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
-            location ^~ /src/ {
-                modsecurity off;
-                proxy_pass http://frontend:3000/src/;
-                proxy_http_version 1.1;
-                proxy_set_header Upgrade $http_upgrade;
-                proxy_set_header Connection $connection_upgrade;
-                proxy_set_header Host $host;
-                proxy_set_header X-Real-IP $remote_addr;
-                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $scheme;
-            }
+        location ^~ /src/ {
+            modsecurity off;
+            proxy_pass http://frontend:3000/src/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
         # Bloquer l'accès aux fichiers sensibles
         location ~ /\. {
@@ -183,4 +383,5 @@ http {
             add_header Content-Type application/json;
         }
     }
-}
+
+    


### PR DESCRIPTION
Ce PR stabilise l’accès à l’app via le WAF (HTTP/HTTPS) et fiabilise le flux Register/Login en supprimant les appels cross-origin.

Points clés:

- Same-origin côté frontend: l’UI appelle /api/... et laisse le WAF router vers l’API Gateway (réduit les problèmes CORS).
- WAF: proxy /api/* → api-gateway:8000 en proxy_pass statique (résolution DNS plus fiable sous Podman), rewrite pour les routes sensibles, et activation TLS sur 443 (donc 8443 côté host OK).
- Réseau: ajout d’un réseau “edge” pour séparer l’exposition (WAF) du backend (gateway/services).
- Vault: permissions [/vault/data](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) robustes même avec un volume existant.
- Dev ergonomie: Makefile plus robuste (detach + remove-orphans).
- Doc: rapport détaillé ajouté.


Fichiers touchés:

- [nginx.conf]
- [useAuth.ts](
- [docker-compose.yml]
- [Dockerfile]
- [setting.sh]
- [Makefile]

Validation rapide:

- make up
- Ouvrir http://localhost:8080 et https://localhost:8443
- Tester [POST /api/auth/login], GET /api/auth/me, [POST /api/users/auth/register] via l’UI ou curl
- Vérifier que [/api/health] répond via le WAF