### PR TITLE
fix: corriger les 403 WAF sur le chargement des assets en local/solo

### DIFF
--- a/srcs/frontend/src/Gameplay/LocalMode.tsx
+++ b/srcs/frontend/src/Gameplay/LocalMode.tsx
@@ -1,13 +1,22 @@
-import { useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 import { GameModeView } from './GameModeView'
 
-const LocalMode = () => {
-  const [searchParams] = useSearchParams()
+interface LocalModeState {
+  player1Name?: string
+  player2Name?: string
+  player1Nation?: string
+  player2Nation?: string
+}
 
-  const player1Name = searchParams.get('player1') || 'Joueur 1'
-  const player2Name = searchParams.get('player2') || 'Joueur 2'
-  const player1Nation = searchParams.get('p1Nation') || 'Algeria'
-  const player2Nation = searchParams.get('p2Nation') || 'Algeria'
+const LocalMode = () => {
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const state = (location.state as LocalModeState | null) ?? null
+
+  const player1Name = state?.player1Name || searchParams.get('player1') || 'Joueur 1'
+  const player2Name = state?.player2Name || searchParams.get('player2') || 'Joueur 2'
+  const player1Nation = state?.player1Nation || searchParams.get('p1Nation') || 'Algeria'
+  const player2Nation = state?.player2Nation || searchParams.get('p2Nation') || 'Algeria'
 
   return (
     <GameModeView

--- a/srcs/frontend/src/Gameplay/SoloMode.tsx
+++ b/srcs/frontend/src/Gameplay/SoloMode.tsx
@@ -1,15 +1,22 @@
-import { useSearchParams } from 'react-router-dom'
+import { useLocation, useSearchParams } from 'react-router-dom'
 import { GameModeView } from './GameModeView'
 import { getCurrentUser } from '../utils/auth'
 
+interface SoloModeState {
+  playerNation?: string
+  aiNation?: string
+}
+
 const SoloMode = () => {
+  const location = useLocation()
   const [searchParams] = useSearchParams()
+  const state = (location.state as SoloModeState | null) ?? null
 
   const user = getCurrentUser()
   const playerName = user?.username || searchParams.get('playerName') || 'Joueur'
   const aiName = searchParams.get('player2') || searchParams.get('ai') || 'CPU'
-  const playerNation = searchParams.get('player') || 'Algeria'
-  const aiNation = searchParams.get('ai') || 'Algeria'
+  const playerNation = state?.playerNation || searchParams.get('player') || 'Algeria'
+  const aiNation = state?.aiNation || searchParams.get('ai') || 'Algeria'
 
   return (
     <GameModeView

--- a/srcs/frontend/src/Local/Charselect.tsx
+++ b/srcs/frontend/src/Local/Charselect.tsx
@@ -87,7 +87,14 @@ const Charselectsolo = () => {
                             ? (currentUser?.username || "Player 1")
                             : (player1Name.trim() || "Player 1");
                         const opponentName = player2Name.trim() || "Player 2";
-                        navigate(`/local-gameplay?player1=${encodeURIComponent(player1DisplayName)}&player2=${encodeURIComponent(opponentName)}&p1Nation=${encodeURIComponent(player)}&p2Nation=${encodeURIComponent(ai)}`);
+                        navigate(`/local-gameplay?p1Nation=${encodeURIComponent(player)}&p2Nation=${encodeURIComponent(ai)}`, {
+                            state: {
+                                player1Name: player1DisplayName,
+                                player2Name: opponentName,
+                                player1Nation: player,
+                                player2Nation: ai,
+                            },
+                        });
                     }}
                     className="font-arcade text-black bg-[#4AD95A] px-8 py-5 min-[481px]:px-7 min-[481px]:py-3 min-[769px]:px-9 min-[769px]:py-4 m-2 text-base min-[481px]:text-lg min-[769px]:text-4xl border-0 shadow-[0px_4px_rgb(255,255,255),0px_-4px_rgb(255,255,255),4px_0px_rgb(255,255,255),-4px_0px_rgb(255,255,255),0px_4px_rgba(0,0,0,0.22),4px_4px_rgba(0,0,0,0.22),-4px_4px_rgba(0,0,0,0.22),inset_0px_4px_rgba(255,255,255,0.21)] cursor-pointer no-underline inline-block transition-transform duration-100 active:translate-y-0.5 w-fit max-w-full"
                 >

--- a/srcs/frontend/src/Solo/Charselect.tsx
+++ b/srcs/frontend/src/Solo/Charselect.tsx
@@ -49,7 +49,12 @@ const Charselectsolo = () => {
 
                 <button
                     onClick={() => {
-                        navigate(`/solo-gameplay?player=${encodeURIComponent(player)}&ai=${encodeURIComponent(ai)}`);
+                        navigate('/solo-gameplay', {
+                            state: {
+                                playerNation: player,
+                                aiNation: ai,
+                            },
+                        });
                     }}
                     className="font-arcade text-black bg-[#4AD95A] px-8 py-5 min-[481px]:px-7 min-[481px]:py-3 min-[769px]:px-9 min-[769px]:py-4 m-2 text-base min-[481px]:text-lg min-[769px]:text-4xl border-0 shadow-[0px_4px_rgb(255,255,255),0px_-4px_rgb(255,255,255),4px_0px_rgb(255,255,255),-4px_0px_rgb(255,255,255),0px_4px_rgba(0,0,0,0.22),4px_4px_rgba(0,0,0,0.22),-4px_4px_rgba(0,0,0,0.22),inset_0px_4px_rgba(255,255,255,0.21)] cursor-pointer no-underline inline-block transition-transform duration-100 active:translate-y-0.5 w-fit max-w-full"
                 >


### PR DESCRIPTION
Cause:

- Les URLs de gameplay incluaient des paramètres de noms joueurs (ex: player2=Player 2).

- Cette query string se retrouvait dans l'en-tête Referer des requêtes d'images statiques (/assets/*.png, /assets/*.jpg).

- ModSecurity (OWASP CRS) interprétait ce Referer comme suspect (règle 932206), ce qui menait à un score d'anomalie bloquant (949110) et des réponses 403.

Patch appliqué:

- Suppression du passage des noms joueurs dans la query string pour les flux Local et Solo.

- Passage des données de partie via navigate(..., { state }) depuis les écrans de sélection.

- Lecture prioritaire des données depuis location.state dans LocalMode et SoloMode.

- Conservation d'un fallback sur les anciens query params pour compatibilité (reload/liens existants).

Résultat attendu:

- Le Referer ne contient plus les paramètres joueurs sensibles côté gameplay.

- Les assets statiques se chargent sans 403 intermittents liés au WAF.